### PR TITLE
SyntaxError: f-string: unmatched '['

### DIFF
--- a/comicwalker_downloader/comic_downloader.py
+++ b/comicwalker_downloader/comic_downloader.py
@@ -12,7 +12,7 @@ class ComicDownloader:
     @staticmethod
     def _fetch_episode(ep: dict, output_dir: str) -> None:
         try:
-            url = f'https://comic-walker.com/api/contents/viewer?episodeId={ep['id']}&imageSizeType=width%3A768'
+            url = f"https://comic-walker.com/api/contents/viewer?episodeId={ep['id']}&imageSizeType=width%3A768'"
             response = requests.get(
                 url,
                 headers={

--- a/comicwalker_downloader/comic_downloader.py
+++ b/comicwalker_downloader/comic_downloader.py
@@ -12,7 +12,7 @@ class ComicDownloader:
     @staticmethod
     def _fetch_episode(ep: dict, output_dir: str) -> None:
         try:
-            url = f"https://comic-walker.com/api/contents/viewer?episodeId={ep['id']}&imageSizeType=width%3A768'"
+            url = f"https://comic-walker.com/api/contents/viewer?episodeId={ep['id']}&imageSizeType=width%3A768"
             response = requests.get(
                 url,
                 headers={


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/de9acfdd-5f6c-42ae-90e2-8cd890986e3d)

When running the cowado [comicwalker link], the error SyntaxError: f-string: unmatched '[' comes up in line 15 of comic_downloader.py
The simple fix was to turn the first and last apostrophe into quotation marks instead

![image](https://github.com/user-attachments/assets/3db66244-8272-46e0-93fa-88cd56a4f5e3)
